### PR TITLE
Amend custom frontend docs to add 2 extra needed params

### DIFF
--- a/src/docs/custom-frontend.mdx
+++ b/src/docs/custom-frontend.mdx
@@ -14,6 +14,8 @@ If you need an entirely custom authentication page, you will need to build it yo
 Query options:
 - **redirect** [required] - String (Base64 encoded URL with or without "https://" prefix)
 - method - Enum ("cloud", "comment", "profile-comment")
+- **username** [required] - String (Only used if method is "profile-comment")
+- authProject - String (ID of the Scratch project used for authentication)
 
 <br />
 


### PR DESCRIPTION
I noticed a couple missing query parameters, so I added them to the docs.

Adapted from [Steve0Greatness/PenguinMod-Home:auth `src/routes/auth/README.md` # Scratch Auth API](https://github.com/Steve0Greatness/PenguinMod-Home/blob/auth/src/routes/auth/README.md#scratch-auth-api)