### PR TITLE
Add NotFenixio's ScratchAuth Demo to the demo list

### DIFF
--- a/src/docs/using-scratch-auth.mdx
+++ b/src/docs/using-scratch-auth.mdx
@@ -128,3 +128,4 @@ The following are functional implementations of an authentication system that us
 
 -   **NFlex23's JWT Auth Demo:** [website](https://scratch-auth-demo.mystpi.repl.co/) | [source code](https://replit.com/@MystPi/Scratch-Auth-Demo)
 -   **Chiroyce's Auth Site:** [website](https://auth.chiroyce.repl.co/) | [source code](https://replit.com/@Chiroyce/auth)
+-   **NotFenixio's ScratchAuth Demo:** [website](https://scratch-auth-demo.vercel.app/) | [source code](https://github.com/NotFenixio/ScratchAuthDemo/blob/main/api/index.py)


### PR DESCRIPTION
Since the two examples in the "Using Scratch Auth in your website" page were taken down due to Replit's new updates, I decided to create one that uses Vercel Serverless Functions to stay afloat.

I used part of Chiroyce's code, but credited them in the source code and front page.